### PR TITLE
Implemented TimestampableInterface

### DIFF
--- a/Model/InventoryUnit.php
+++ b/Model/InventoryUnit.php
@@ -11,6 +11,8 @@
 
 namespace Sylius\Bundle\InventoryBundle\Model;
 
+use DateTime;
+
 /**
  * Inventory unit model.
  *
@@ -142,8 +144,24 @@ class InventoryUnit implements InventoryUnitInterface
     /**
      * {@inheritdoc}
      */
+    public function setCreatedAt(DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdatedAt(DateTime $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
     }
 }

--- a/Model/InventoryUnitInterface.php
+++ b/Model/InventoryUnitInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Bundle\InventoryBundle\Model;
 
+use Sylius\Bundle\ResourceBundle\Model\TimestampableInterface;
+
 /**
  * Inventory unit interface.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
-interface InventoryUnitInterface
+interface InventoryUnitInterface extends TimestampableInterface
 {
     /**
      * Default states.
@@ -86,18 +88,4 @@ interface InventoryUnitInterface
      * @return Boolean
      */
     public function isBackordered();
-
-    /**
-     * Get creation time.
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt();
-
-    /**
-     * Get last update time.
-     *
-     * @return \DateTime
-     */
-    public function getUpdatedAt();
 }

--- a/spec/Sylius/Bundle/InventoryBundle/Model/InventoryUnit.php
+++ b/spec/Sylius/Bundle/InventoryBundle/Model/InventoryUnit.php
@@ -22,6 +22,11 @@ class InventoryUnit extends ObjectBehavior
         $this->shouldImplement('Sylius\Bundle\InventoryBundle\Model\InventoryUnitInterface');
     }
 
+    function it_should_implement_timestampable_interface()
+    {
+        $this->shouldImplement('Sylius\Bundle\ResourceBundle\Model\TimestampableInterface');
+    }
+
     function it_should_not_have_id_by_default()
     {
         $this->getId()->shouldReturn(null);


### PR DESCRIPTION
This is important to make it compatible with latest main app.

https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Model/InventoryUnitInterface.php#L24 and ShipmentItemInterface extends TimestampableInterface which leads then to fatal error.
